### PR TITLE
Update dependency and avoid NU1701

### DIFF
--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -35,8 +35,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Drawing.Common.4.5.1\lib\net461\System.Drawing.Common.dll</HintPath>
+    <Reference Include="System.Drawing.Common, Version=4.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Drawing.Common.5.0.1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Example/packages.config
+++ b/Example/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Drawing.Common" version="4.5.1" targetFramework="net461" />
+  <package id="System.Drawing.Common" version="5.0.1" targetFramework="net461" />
 </packages>

--- a/FaviconFetcher.Tests/FaviconFetcher.Tests.csproj
+++ b/FaviconFetcher.Tests/FaviconFetcher.Tests.csproj
@@ -74,7 +74,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets'))" />

--- a/FaviconFetcher.Tests/FaviconFetcher.Tests.csproj
+++ b/FaviconFetcher.Tests/FaviconFetcher.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -40,16 +40,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Drawing.Common.4.5.1\lib\net461\System.Drawing.Common.dll</HintPath>
+    <Reference Include="System.Drawing.Common, Version=4.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Drawing.Common.5.0.1\lib\net461\System.Drawing.Common.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -62,22 +62,22 @@
     <Compile Include="ManifestJsonScannerTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FaviconFetcher\FaviconFetcher.csproj">
       <Project>{fa32a521-eb11-4e9a-a31a-28195ec9fe27}</Project>
       <Name>FaviconFetcher</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/FaviconFetcher.Tests/packages.config
+++ b/FaviconFetcher.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net461" />
-  <package id="System.Drawing.Common" version="4.5.1" targetFramework="net461" />
+  <package id="MSTest.TestAdapter" version="2.1.2" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="2.1.2" targetFramework="net461" />
+  <package id="System.Drawing.Common" version="5.0.1" targetFramework="net461" />
 </packages>

--- a/FaviconFetcher/ConcurrentPriorityQueue/AbstractPriorityQueue.cs
+++ b/FaviconFetcher/ConcurrentPriorityQueue/AbstractPriorityQueue.cs
@@ -1,0 +1,335 @@
+﻿/*
+#The MIT License (MIT)
+
+Copyright (c) 2015 Denis Shulepov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ConcurrentPriorityQueue
+{
+    /// <summary>
+    /// Heap-based implementation of priority queue.
+    /// </summary>
+    public abstract class AbstractPriorityQueue<TElement, TPriority> : IPriorityQueue<TElement, TPriority> where TPriority : IComparable<TPriority>
+    {
+        internal sealed class Node
+        {
+            public TPriority Priority { get; internal set; }
+            public readonly TElement Element;
+
+            public Node(TElement element, TPriority priority)
+            {
+                Priority = priority;
+                Element = element;
+            }
+        }
+
+        internal Node[] _nodes;
+        internal int _count;
+        internal readonly NodeComparer _comparer;
+        private readonly bool _dataIsValueType;
+
+        /// <summary>
+        /// Create an empty max priority queue of given capacity.
+        /// </summary>
+        /// <param name="capacity">Queue capacity. Greater than 0.</param>
+        /// <param name="comparer">Priority comparer. Default type comparer will be used unless custom is provided.</param>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        internal AbstractPriorityQueue(int capacity, IComparer<TPriority> comparer = null)
+        {
+            if (capacity <= 0) throw new ArgumentOutOfRangeException("capacity", "Expected capacity greater than zero.");
+
+            _nodes = new Node[capacity + 1];        // first element at 1
+            _count = 0;
+            _comparer = new NodeComparer(comparer ?? Comparer<TPriority>.Default);
+            _dataIsValueType = typeof (TElement).IsValueType;
+        }
+
+        /// <summary>
+        /// Create a new priority queue from the given nodes storage and comparer.
+        /// Used to create existing queue copies. 
+        /// </summary>
+        /// <param name="nodes">Heap with data.</param>
+        /// <param name="count">Count of items in the heap.</param>
+        /// <param name="comparer">Node comparer for nodes in the queue.</param>
+        internal AbstractPriorityQueue(Node[] nodes, int count, NodeComparer comparer)
+        {
+            _nodes = nodes;
+            _count = count;
+            _comparer = comparer;
+            _dataIsValueType = typeof(TElement).IsValueType;
+        }
+
+        public int Capacity { get { return _nodes.Length - 1; } }
+
+        public int Count { get { return _count; } }
+
+        /// <summary>
+        /// Returns true if there is at least one item, which is equal to given.
+        /// TElement.Equals is used to compare equality.
+        /// </summary>
+        public virtual bool Contains(TElement item)
+        {
+            return GetItemIndex(item) > 0;
+        }
+
+        /// <summary>
+        /// Returns index of the first occurrence of the given item or 0.
+        /// TElement.Equals is used to compare equality.
+        /// </summary>
+        private int GetItemIndex(TElement item)
+        {
+            for (int i = 1; i <= _count; i++)
+            {
+                if (Equals(_nodes[i].Element, item)) return i;
+            }
+            return 0;            
+        }
+
+        /// <summary>
+        /// Check if given data items are equal using TD.Equals.
+        /// Handles null values for object types.
+        /// </summary>
+        internal bool Equals(TElement a, TElement b)
+        {
+            if (_dataIsValueType)
+            {
+                return a.Equals(b);
+            }
+
+            var objA = a as object;
+            var objB = b as object;
+            if (objA == null && objB == null) return true;      // null == null because equality should be symmetric
+            if (objA == null || objB == null) return false;
+            return objA.Equals(objB);
+        }
+
+        public virtual void Enqueue(TElement item, TPriority priority)
+        {
+            int index = _count + 1;
+            _nodes[index] = new Node(item, priority);
+
+            _count = index;             // update count after the element is really added but before Sift
+
+            Sift(index);                // move item "up" while heap principles are not met
+        }
+
+        public virtual TElement Dequeue()
+        {
+            if (_count == 0) throw new InvalidOperationException("Unable to dequeue from empty queue.");
+
+            TElement item = _nodes[1].Element;   // first element at 1
+            Swap(1, _count);            // last element at _count
+            _nodes[_count] = null;      // release hold on the object
+
+            _count--;                   // update count after the element is really gone but before Sink
+
+            Sink(1);                    // move item "down" while heap principles are not met
+
+            return item;
+        }
+
+        /// <summary>
+        /// Returns the first element in the queue (element with max priority) without removing it from the queue.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public virtual TElement Peek()
+        {
+            if (_count == 0) throw new InvalidOperationException("Unable to peek from empty queue.");
+
+            return _nodes[1].Element;   // first element at 1
+        }
+
+        /// <summary>
+        /// Remove all items from the queue. Capacity is not changed.
+        /// </summary>
+        public virtual void Clear()
+        {
+            for (int i = 1; i <= _count; i++)
+            {
+                _nodes[i] = null;
+            }
+            _count = 0;
+        }
+
+        /// <summary>
+        /// Update priority of the first occurrence of the given item
+        /// </summary>
+        /// <param name="item">Item, which priority should be updated.</param>
+        /// <param name="priority">New priority</param>
+        /// <exception cref="ArgumentException"></exception>
+        public virtual void UpdatePriority(TElement item, TPriority priority)
+        {
+            var index = GetItemIndex(item);
+            if (index == 0) throw new ArgumentException("Item is not found in the queue.");
+
+            var priorityCompare = _comparer.Compare(_nodes[index].Priority, priority);
+            if (priorityCompare < 0)
+            {
+                _nodes[index].Priority = priority;
+                Sift(index);            // priority is increased, so item should go "up" the heap
+            }
+            else if (priorityCompare > 0)
+            {
+                _nodes[index].Priority = priority;
+                Sink(index);            // priority is decreased, so item should go "down" the heap
+            }
+        }
+
+        /// <summary>
+        /// Returns a copy of internal heap array. Number of elements is _count + 1;
+        /// </summary>
+        /// <returns></returns>
+        internal Node[] CopyNodes()
+        {
+            var nodesCopy = new Node[_count + 1];
+            Array.Copy(_nodes, 0, nodesCopy, 0, _count + 1);
+            return nodesCopy;
+        }
+
+        private bool GreaterOrEqual(Node i, Node j)
+        {
+            return _comparer.Compare(i, j) >= 0;
+        }
+
+        /// <summary>
+        /// Moves the item with given index "down" the heap while heap principles are not met.
+        /// </summary>
+        private void Sink(int i)
+        {
+            while (true)
+            {
+                int leftChildIndex = 2 * i;
+                int rightChildIndex = 2 * i + 1;
+                if (leftChildIndex > _count) return; // reached last item
+
+                var item = _nodes[i];
+                var left = _nodes[leftChildIndex];
+                var right = rightChildIndex > _count ? null : _nodes[rightChildIndex];
+
+                // if item is greater than children - exit
+                if (GreaterOrEqual(item, left) && (right == null || GreaterOrEqual(item, right))) return;
+
+                // else exchange with greater of children
+                int greaterChild = right == null || GreaterOrEqual(left, right) ? leftChildIndex : rightChildIndex;
+                Swap(i, greaterChild);
+
+                // continue at new position
+                i = greaterChild;
+            }
+        }
+
+        /// <summary>
+        /// Moves the item with given index "up" the heap while heap principles are not met.
+        /// </summary>
+        private void Sift(int i)
+        {
+            while (true)
+            {
+                if (i <= 1) return;         // reached root
+                int parent = i / 2;         // get parent
+
+                // if root is greater or equal - exit
+                if (GreaterOrEqual(_nodes[parent], _nodes[i])) return;
+
+                Swap(parent, i);
+                i = parent;
+            }
+        }
+
+        private void Swap(int i, int j)
+        {
+            var tmp = _nodes[i];
+            _nodes[i] = _nodes[j];
+            _nodes[j] = tmp;
+        }
+
+        public abstract IEnumerator<TElement> GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Compare nodes based on priority or just priorities
+        /// </summary>
+        internal sealed class NodeComparer : IComparer<Node>, IComparer<TPriority>
+        {
+            private readonly IComparer<TPriority> _comparer;
+
+            public NodeComparer(IComparer<TPriority> comparer)
+            {
+                _comparer = comparer;
+            }
+
+            public int Compare(Node x, Node y)
+            {
+                if (x == null && y == null) return 0;
+                if (x == null) return -1;
+                if (y == null) return 1;
+
+                return _comparer.Compare(x.Priority, y.Priority);
+            }
+
+            public int Compare(TPriority x, TPriority y)
+            {
+                return _comparer.Compare(x, y);
+            }
+        }
+
+        /// <summary>
+        /// Queue items enumerator. Returns items in the oder of queue priority.
+        /// </summary>
+        internal sealed class PriorityQueueEnumerator : IEnumerator<TElement>
+        {
+            private readonly TElement[] _items;
+            private int _currentIndex;
+
+            internal PriorityQueueEnumerator(AbstractPriorityQueue<TElement, TPriority> queueCopy)
+            {
+                _items = new TElement[queueCopy.Count];
+
+                // dequeue the given queue copy to extract items in order of priority
+                // enumerator is based on the new array to allow reset and multiple enumerations
+                for (int i = 0; i < _items.Length; i++)
+                {
+                    _items[i] = queueCopy.Dequeue();
+                }
+
+                Reset();
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                _currentIndex++;
+                return _currentIndex < _items.Length;
+            }
+
+            public void Reset()
+            {
+                _currentIndex = -1;
+            }
+
+            public TElement Current { get { return _items[_currentIndex]; } }
+
+            object IEnumerator.Current
+            {
+                get { return Current; }
+            }
+        }
+    }
+}

--- a/FaviconFetcher/ConcurrentPriorityQueue/ConcurrentPriorityQueue.cs
+++ b/FaviconFetcher/ConcurrentPriorityQueue/ConcurrentPriorityQueue.cs
@@ -1,0 +1,172 @@
+﻿/*
+#The MIT License (MIT)
+
+Copyright (c) 2015 Denis Shulepov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace ConcurrentPriorityQueue
+{
+    /// <summary>
+    /// Heap-based implementation of concurrent priority queue. Max priority is on top of the heap.
+    /// </summary>
+    public class ConcurrentPriorityQueue<TElement, TPriority> : AbstractPriorityQueue<TElement, TPriority> where TPriority : IComparable<TPriority>
+    {
+        private readonly object _sync = new object();
+        private const int _defaultCapacity = 10;
+        private const int _shrinkRatio = 4;
+        internal const int _resizeFactor = 2;
+
+        private int _shrinkBound;
+
+        /// <summary>
+        /// Create a new instance of priority queue with given initial capacity.
+        /// </summary>
+        /// <param name="capacity">Initial queue capacity. Should be greater than 0.</param>
+        /// <param name="comparer">Priority comparer. Default for type will be used unless custom is provided.</param>
+        public ConcurrentPriorityQueue(int capacity, IComparer<TPriority> comparer = null):base(capacity, comparer)
+        {
+            _shrinkBound = Capacity / _shrinkRatio;
+        }
+
+        /// <summary>
+        /// Create a new instance of priority queue with default initial capacity.
+        /// </summary>
+        /// <param name="comparer">Priority comparer. Default for type will be used unless custom is provided.</param>
+        public ConcurrentPriorityQueue(IComparer<TPriority> comparer = null): this(_defaultCapacity, comparer)
+        {
+        }
+
+        private ConcurrentPriorityQueue(Node[] nodes, int count, NodeComparer comparer):base(nodes, count, comparer)
+        { }
+
+        /// <summary>
+        /// Add new item to the queue.
+        /// </summary>
+        public override void Enqueue(TElement item, TPriority priority)
+        {
+            lock (_sync)
+            {
+                if (_count == Capacity) GrowCapacity();
+
+                base.Enqueue(item, priority);
+            }
+        }
+
+        /// <summary>
+        /// Remove and return the item with max priority from the queue.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public override TElement Dequeue()
+        {
+            TElement item;
+            lock (_sync)
+            {
+                item = base.Dequeue();
+
+                if (_count <= _shrinkBound && _count > _defaultCapacity) ShrinkCapacity();
+            }
+
+            return item;
+        }
+
+        /// <summary>
+        /// Trim queue capacity to count of items in the queue
+        /// </summary>
+        public void Trim()
+        {
+            lock (_sync)
+            {
+                int newCapacity = _count;
+                Array.Resize(ref _nodes, newCapacity + 1);  // first element is at position 1
+                _shrinkBound = newCapacity / _shrinkRatio;
+            }
+        }
+
+        /// <summary>
+        /// Remove all items from the queue. Capacity is not changed.
+        /// </summary>
+        public override void Clear()
+        {
+            lock (_sync)
+            {
+                base.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Returns true if there is at least one item, which is equal to given.
+        /// TD.Equals is used to compare equality.
+        /// </summary>
+        public override bool Contains(TElement item)
+        {
+            lock (_sync)
+            {
+                return base.Contains(item);
+            }
+        }
+
+        /// <summary>
+        /// Returns the first element in the queue (element with max priority) without removing it from the queue.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public override TElement Peek()
+        {
+            lock (_sync)
+            {
+                return base.Peek();
+            }
+        }
+
+        /// <summary>
+        /// Update priority of the first occurrence of the given item
+        /// </summary>
+        /// <param name="item">Item, which priority should be updated.</param>
+        /// <param name="priority">New priority</param>
+        /// <exception cref="ArgumentException"></exception>
+        public override void UpdatePriority(TElement item, TPriority priority)
+        {
+            lock (_sync)
+            {
+                base.UpdatePriority(item, priority);
+            }
+        }
+
+        public override IEnumerator<TElement> GetEnumerator()
+        {
+            Node[] nodesCopy;
+            lock (_sync)
+            {
+                nodesCopy = CopyNodes();
+            }
+            // queue copy is created to be able to extract the items in the priority order
+            // using the already existing dequeue method
+            // (because they are not exactly in priority order in the underlying array)
+            var queueCopy = new ConcurrentPriorityQueue<TElement, TPriority>(nodesCopy, nodesCopy.Length - 1, _comparer);
+
+            return new PriorityQueueEnumerator(queueCopy);
+        }
+
+        private void GrowCapacity()
+        {
+            int newCapacity = Capacity * _resizeFactor;
+            Array.Resize(ref _nodes, newCapacity + 1);  // first element is at position 1
+            _shrinkBound = newCapacity / _shrinkRatio;
+        }
+
+        private void ShrinkCapacity()
+        {
+            int newCapacity = Capacity / _resizeFactor;
+            Array.Resize(ref _nodes, newCapacity + 1);  // first element is at position 1
+            _shrinkBound = newCapacity / _shrinkRatio;
+        }
+    }
+}

--- a/FaviconFetcher/ConcurrentPriorityQueue/IPriorityQueue.cs
+++ b/FaviconFetcher/ConcurrentPriorityQueue/IPriorityQueue.cs
@@ -1,0 +1,29 @@
+﻿/*
+#The MIT License (MIT)
+
+Copyright (c) 2015 Denis Shulepov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace ConcurrentPriorityQueue
+{
+    public interface IPriorityQueue<TElement, in TPriority> : IEnumerable<TElement> where TPriority : IComparable<TPriority>
+    {
+        int Capacity { get; }
+        int Count { get; }
+        bool Contains(TElement item);
+        void Enqueue(TElement item, TPriority priority);
+        TElement Dequeue();
+        TElement Peek();
+        void Clear();
+        void UpdatePriority(TElement item, TPriority priority);
+    }
+}

--- a/FaviconFetcher/FaviconFetcher.csproj
+++ b/FaviconFetcher/FaviconFetcher.csproj
@@ -15,8 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PriorityQueue" Version="0.1.0" />
-    <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated System.Drawing.Common and MSTest.*. Removed PriorityQueue from ItemGroup and imported it locally to avoid NU1701.

[ConcurrentPriorityQueue](https://github.com/dshulepov/ConcurrentPriorityQueue) is no longer maintained (6 years ago) and the target framework is not .Net Standard. Importing files locally is not best but easy fix.