### PR TITLE
Replace System.Drawing dependency with SkiaSharp for portability

### DIFF
--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="SkiaSharp.Views" Version="2.88.3" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/Example/FetcherTest.cs
+++ b/Example/FetcherTest.cs
@@ -1,4 +1,5 @@
 ﻿using FaviconFetcher;
+using SkiaSharp.Views.Desktop;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -32,14 +33,14 @@ namespace Example
 
                 var image = new Fetcher().Fetch(uri, new FetchOptions
                 {
-                    MinimumSize = new Size(minSize, minSize),
-                    MaximumSize = new Size(maxSize, maxSize),
-                    PerfectSize = new Size(perfectSize, perfectSize)
+                    MinimumSize = new IconSize(minSize, minSize),
+                    MaximumSize = new IconSize(maxSize, maxSize),
+                    PerfectSize = new IconSize(perfectSize, perfectSize)
                 });
                 if (image != null)
                 {
-                    picIcon.Size = image.Size;
-                    picIcon.Image = image;
+                    picIcon.Size = new Size(image.Size.Width, image.Size.Height);
+                    picIcon.Image = image.ToSKBitmap().ToBitmap();
                 }
             }
             catch (Exception ex)

--- a/Example/ScannerTest.cs
+++ b/Example/ScannerTest.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
-using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/FaviconFetcher.Tests/DefaultScannerTests.cs
+++ b/FaviconFetcher.Tests/DefaultScannerTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using FaviconFetcher.SubScanners;
 using FaviconFetcher.Tests.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -25,7 +24,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicon.png"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 
@@ -45,7 +44,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicon.png"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 
@@ -65,7 +64,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicon.png"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 
@@ -101,12 +100,12 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicons.ico"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicons.ico"),
-                ExpectedSize = new Size(32, 32)
+                ExpectedSize = new IconSize(32, 32)
             }, scanner.Results[1]);
         }
 
@@ -143,7 +142,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/apple_icon.png"),
-                ExpectedSize = new Size(57, 57)
+                ExpectedSize = new IconSize(57, 57)
             }, scanner.Results[0]);
         }
 
@@ -163,7 +162,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/apple_icon.png"),
-                ExpectedSize = new Size(48, 48)
+                ExpectedSize = new IconSize(48, 48)
             }, scanner.Results[0]);
         }
 
@@ -183,7 +182,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicon_48x48.png"),
-                ExpectedSize = new Size(48, 48)
+                ExpectedSize = new IconSize(48, 48)
             }, scanner.Results[0]);
         }
 
@@ -203,7 +202,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicon_48x48.png"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 
@@ -223,7 +222,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/icon_21474836470_48.png"),
-                ExpectedSize = new Size(48, 48)
+                ExpectedSize = new IconSize(48, 48)
             }, scanner.Results[0]);
         }
 
@@ -259,7 +258,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicon's.png"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 
@@ -280,7 +279,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicon.ico"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 
@@ -301,7 +300,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.other.com/favicon.ico"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 
@@ -322,7 +321,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.other.com/favicon.ico"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 
@@ -343,7 +342,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/icons/favicon.ico"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 
@@ -364,7 +363,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicon.ico"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 
@@ -385,7 +384,7 @@ namespace FaviconFetcher.Tests
             Assert.AreEqual(new ScanResult
             {
                 Location = new Uri("http://www.example.com/favicon.ico"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             }, scanner.Results[0]);
         }
 

--- a/FaviconFetcher.Tests/FetcherTests.cs
+++ b/FaviconFetcher.Tests/FetcherTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using FaviconFetcher.Tests.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -16,7 +15,7 @@ namespace FaviconFetcher.Tests
             source.AddTextResource(uri, "Fake content.");
 
             var fetcher = new Fetcher(source);
-            fetcher.FetchClosest(uri, new Size(16, 16));
+            fetcher.FetchClosest(uri, new IconSize(16, 16));
 
             Assert.AreEqual(2, source.RequestCount);
         }
@@ -32,7 +31,7 @@ namespace FaviconFetcher.Tests
                 </head></html>");
 
             var fetcher = new Fetcher(source);
-            fetcher.FetchClosest(uri, new Size(16, 16));
+            fetcher.FetchClosest(uri, new IconSize(16, 16));
 
             Assert.AreEqual(3, source.RequestCount);
         }
@@ -47,11 +46,11 @@ namespace FaviconFetcher.Tests
                     <link rel='shortcut icon' href='favicon_32.png' sizes='32x32'>
                     <link rel='shortcut icon' href='favicon_16.png' sizes='16x16'>
                 </head></html>");
-            source.AddImageResource(new Uri(uri, "/favicon_32.png"), new Size(32, 32));
-            source.AddImageResource(new Uri(uri, "/favicon_16.png"), new Size(16, 16));
+            source.AddImageResource(new Uri(uri, "/favicon_32.png"), new IconSize(32, 32));
+            source.AddImageResource(new Uri(uri, "/favicon_16.png"), new IconSize(16, 16));
 
             var fetcher = new Fetcher(source);
-            fetcher.FetchClosest(uri, new Size(16, 16));
+            fetcher.FetchClosest(uri, new IconSize(16, 16));
 
             Assert.AreEqual(2, source.RequestCount);
         }
@@ -62,15 +61,15 @@ namespace FaviconFetcher.Tests
             var uri = new Uri("http://www.example.com");
             var source = new MockSource();
             source.AddTextResource(uri, "Fake content.");
-            source.AddImageResource(new Uri(uri, "/favicon.ico"), new Size(16, 16));
-            source.AddImageResource(new Uri(uri, "/favicon.ico"), new Size(32, 32));
-            source.AddImageResource(new Uri(uri, "/favicon.ico"), new Size(48, 48));
+            source.AddImageResource(new Uri(uri, "/favicon.ico"), new IconSize(16, 16));
+            source.AddImageResource(new Uri(uri, "/favicon.ico"), new IconSize(32, 32));
+            source.AddImageResource(new Uri(uri, "/favicon.ico"), new IconSize(48, 48));
 
             var fetcher = new Fetcher(source);
-            var image = fetcher.FetchClosest(uri, new Size(32, 32));
+            var image = fetcher.FetchClosest(uri, new IconSize(32, 32));
 
             Assert.AreEqual(2, source.RequestCount);
-            Assert.AreEqual(new Size(32, 32), image.Size);
+            Assert.AreEqual(new IconSize(32, 32), image.Size);
         }
     }
 }

--- a/FaviconFetcher.Tests/ScannerTests.cs
+++ b/FaviconFetcher.Tests/ScannerTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Drawing;
 using System.Linq;
 using FaviconFetcher.Tests.Utility;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/FaviconFetcher.Tests/Utility/MockSource.cs
+++ b/FaviconFetcher.Tests/Utility/MockSource.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using SkiaSharp;
+using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -11,7 +11,7 @@ namespace FaviconFetcher.Tests.Utility
     class MockSource : ISource, IDisposable
     {
         private Dictionary<Uri, string> _textResourceMap = new Dictionary<Uri, string>();
-        private Dictionary<Uri, List<Image>> _imageResourceMap = new Dictionary<Uri, List<Image>>();
+        private Dictionary<Uri, List<IconImage>> _imageResourceMap = new Dictionary<Uri, List<IconImage>>();
 
         public int RequestCount { get; private set; } = 0;
 
@@ -29,27 +29,27 @@ namespace FaviconFetcher.Tests.Utility
             _textResourceMap.Add(uri, contents);
         }
 
-        public void AddImageResource(Uri uri, Size imageSize)
+        public void AddImageResource(Uri uri, IconSize imageSize)
         {
-            using (var bitmap = new Bitmap(1, 1))
+            using (var bitmap = new SKBitmap(1, 1))
             {
-                bitmap.SetPixel(0, 0, Color.DarkSlateBlue);
-                AddImageResource(uri, new Bitmap(bitmap, imageSize));
+                bitmap.SetPixel(0, 0, SKColor.FromHsl(255, 255, 255));
+                AddImageResource(uri, IconImage.FromSKBitmap(bitmap, new IconSize(imageSize.Width, imageSize.Height)));
             }
         }
 
-        public void AddImageResource(Uri uri, Image image)
+        public void AddImageResource(Uri uri, IconImage image)
         {
             if (!_imageResourceMap.ContainsKey(uri))
-                _imageResourceMap.Add(uri, new List<Image>());
+                _imageResourceMap.Add(uri, new List<IconImage>());
             _imageResourceMap[uri].Add(image);
         }
 
-        public IEnumerable<Image> DownloadImages(Uri uri)
+        public IEnumerable<IconImage> DownloadImages(Uri uri)
         {
             ++RequestCount;
             if (!_imageResourceMap.ContainsKey(uri))
-                return new Image[] { };
+                return new IconImage[] { };
             return _imageResourceMap[uri];
         }
 

--- a/FaviconFetcher/Classes/IconImage.cs
+++ b/FaviconFetcher/Classes/IconImage.cs
@@ -1,0 +1,104 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
+
+namespace FaviconFetcher
+{
+    public class IconImage : IDisposable
+    {
+        private SKBitmap _bitmap;
+
+        public IconImage() {
+            Size = IconSize.Empty;
+        }
+
+        public SKBitmap ToSKBitmap()
+        {
+            return _bitmap;
+        }
+
+        public static IconImage FromSKBitmap(SKBitmap bitmap, IconSize size = null)
+        {
+            var icon = new IconImage();
+
+            if (bitmap != null)
+            {
+                if (size == null)
+                    icon._bitmap = bitmap;
+                else
+                    icon._bitmap = bitmap.Resize(new SKSizeI(size.Width, size.Height), SKFilterQuality.High);
+
+                icon.Size = new IconSize(icon._bitmap.Width, icon._bitmap.Height);
+            }
+
+            return icon;
+        }
+
+        public static IconImage FromStream(Stream stream, IconSize size = null)
+        {
+            var icon = new IconImage();
+
+            using (MemoryStream memStream = new MemoryStream())
+            {
+                stream.Position = 0;
+                stream.CopyTo(memStream);
+
+                memStream.Position = 0; // Reset to start for decode
+                var deccodedBitmap = SKBitmap.Decode(memStream);
+
+                return FromSKBitmap(deccodedBitmap, size);
+            }
+        }
+
+        public static IconImage FromIco(Stream stream, IconSize size = null)
+        {
+            return FromStream(stream, size);
+        }
+
+        public static IconImage FromFile(string filename, IconSize size = null)
+        {
+            using (FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read))
+            {
+                return FromStream(fs, size);
+            }
+        }
+
+        public void Dispose()
+        {
+            _bitmap = null;
+            Size = null;
+        }
+
+        public IconSize Size { get; set; }
+
+        public byte[] Bytes
+        {
+            get
+            {
+                return _bitmap.Bytes;
+            }
+        }
+
+        public bool Save(string filename)
+        {
+            try
+            {
+                using (FileStream fs = File.Create(filename))
+                {
+                    SKData d = SKImage.FromBitmap(_bitmap).Encode(SKEncodedImageFormat.Png, 100);
+                    d.SaveTo(fs);
+                }
+
+                return File.Exists(filename);
+            }
+            catch (Exception ex)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/FaviconFetcher/Classes/IconSize.cs
+++ b/FaviconFetcher/Classes/IconSize.cs
@@ -1,0 +1,93 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FaviconFetcher
+{
+    public class IconSize : EqualityComparer<IconSize>, IEquatable<IconSize>
+    {
+        private SKSizeI _size;
+
+        public IconSize()
+        {
+            _size = SKSizeI.Empty;
+        }
+
+        public IconSize(int width, int height)
+        {
+            _size = new SKSizeI(width, height);
+        }
+
+        public int Width
+        {
+            get
+            {
+                return _size.Width;
+            }
+            set
+            {
+                _size.Width = value;
+            }
+        }
+
+        public int Height
+        {
+            get
+            {
+                return _size.Height;
+            }
+            set
+            {
+                _size.Height = value;
+            }
+        }
+
+        public static IconSize Empty
+        {
+            get
+            {
+                return new IconSize();
+            }
+        }
+
+        public bool Equals(IconSize other)
+        {
+            if (other == null) return false;
+
+            return other.Width == this.Width && other.Height == this.Height;
+        }
+
+        public static bool operator == (IconSize lhs, IconSize rhs)
+        {
+            if (ReferenceEquals(lhs, rhs)) return true;
+            if (ReferenceEquals(rhs, null)) return false;
+            if (ReferenceEquals(null, lhs)) return false;
+
+            if (lhs == null) { return rhs == null; }
+            if (rhs == null) { return lhs == null; }
+
+            return rhs.Width == lhs.Width && rhs.Height == lhs.Height;
+        }
+
+        public static bool operator != (IconSize lhs, IconSize rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as IconSize);
+        }
+
+        public override bool Equals(IconSize x, IconSize y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(IconSize obj)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/FaviconFetcher/FaviconFetcher.csproj
+++ b/FaviconFetcher/FaviconFetcher.csproj
@@ -17,14 +17,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\LICENSE.txt">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
   </ItemGroup>
 
 </Project>

--- a/FaviconFetcher/FetchOptions.cs
+++ b/FaviconFetcher/FetchOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,17 +14,17 @@ namespace FaviconFetcher
         /// <summary>
         /// The result will be at least this size.
         /// </summary>
-        public Size MinimumSize { get; set; } = Size.Empty;
+        public IconSize MinimumSize { get; set; } = IconSize.Empty;
 
         /// <summary>
         /// The result will not exceed this size.
         /// </summary>
-        public Size MaximumSize { get; set; } = new Size(4096, 4096);
+        public IconSize MaximumSize { get; set; } = new IconSize(4096, 4096);
 
         /// <summary>
         /// The result will be the closest to this size.
         /// </summary>
-        public Size PerfectSize { get; set; } = Size.Empty;
+        public IconSize PerfectSize { get; set; } = IconSize.Empty;
 
         /// <summary>
         /// Whether to require that the favicon be a square.

--- a/FaviconFetcher/Fetcher.cs
+++ b/FaviconFetcher/Fetcher.cs
@@ -1,6 +1,5 @@
 ﻿using FaviconFetcher.Utility;
 using System;
-using System.Drawing;
 using System.Net;
 
 namespace FaviconFetcher
@@ -36,7 +35,7 @@ namespace FaviconFetcher
         /// <param name="uri">The webpage to scan for favicons.</param>
         /// <param name="size">The target size of the favicon.</param>
         /// <returns>The closest favicon to the size, or null.</returns>
-        public Image FetchClosest(Uri uri, Size size)
+        public IconImage FetchClosest(Uri uri, IconSize size)
         {
             return Fetch(uri, new FetchOptions
             {
@@ -50,7 +49,7 @@ namespace FaviconFetcher
         /// <param name="uri">The webpage to scan for favicons.</param>
         /// <param name="size">The target size of the favicon.</param>
         /// <returns>The favicon matching the size, or null.</returns>
-        public Image FetchExact(Uri uri, Size size)
+        public IconImage FetchExact(Uri uri, IconSize size)
         {
             return Fetch(uri, new FetchOptions
             {
@@ -66,7 +65,7 @@ namespace FaviconFetcher
         /// <param name="uri">The webpage to scan for favicons.</param>
         /// <param name="options">Filters for the returned result.</param>
         /// <returns>The matching favicon, or null.</returns>
-        public Image Fetch(Uri uri, FetchOptions options)
+        public IconImage Fetch(Uri uri, FetchOptions options)
         {
             using (var fetch = new FetchJob(Source, uri, options))
                 return fetch.ScanAndFetch();

--- a/FaviconFetcher/HttpSource.cs
+++ b/FaviconFetcher/HttpSource.cs
@@ -87,7 +87,7 @@ namespace FaviconFetcher
                 response.GetResponseStream().CopyTo(memoryStream);
 
                 // Were we redirected and received a non-image response?
-                if (!response.Equals(response.ResponseUri) 
+                if (!uri.Equals(response.ResponseUri) 
                     && contentType.Contains("text/html"))
                 {
                     responseUri = response.ResponseUri;

--- a/FaviconFetcher/HttpSource.cs
+++ b/FaviconFetcher/HttpSource.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Net;
 using System.Net.Cache;
@@ -72,50 +71,76 @@ namespace FaviconFetcher
         /// </summary>
         /// <param name="uri">The URI of the image file to download.</param>
         /// <returns>All of the images found within the file.</returns>
-        public IEnumerable<Image> DownloadImages(Uri uri)
+        public IEnumerable<IconImage> DownloadImages(Uri uri)
         {
-            var images = new List<Image>();
+            var images = new List<IconImage>();
+            var contentType = string.Empty;
+            var memoryStream = new MemoryStream();
+            Uri responseUri = null;
+
             using (var response = _GetWebResponse(uri))
             {
                 if (response.StatusCode != HttpStatusCode.OK)
                     return images;
 
-                var memoryStream = new MemoryStream();
+                contentType = response.ContentType.ToLower();
                 response.GetResponseStream().CopyTo(memoryStream);
 
-                // Ico file
-                if (_IsContentTypeIco(response.ContentType))
+                // Were we redirected and received a non-image response?
+                if (!response.Equals(response.ResponseUri) 
+                    && contentType.Contains("text/html"))
                 {
-                    try
-                    {
-                        foreach (var size in _ExtractIcoSizes(memoryStream))
-                        {
-                            memoryStream.Position = 0;
-                            images.Add(new Icon(memoryStream, size).ToBitmap());
-                        }
-                        return images;
-                    }
-
-                    // Sometimes a website lies about "ico".
-                    catch (EndOfStreamException) { }
-                    catch (ArgumentException) { }
-                    // We'll let this fall through to try another image type.
-                    memoryStream.Position = 0;
+                    responseUri = response.ResponseUri;
                 }
+            }
 
-                // Other image type
+            if (responseUri != null)
+            {
+                var redirectedUri = new Uri(responseUri.GetLeftPart(UriPartial.Authority).ToString() + uri.PathAndQuery);
+                // Try fetching same resource at the root of the redirected URI
+                using (var response = _GetWebResponse(redirectedUri))
+                {
+                    if (response.StatusCode != HttpStatusCode.OK)
+                        return images;
+
+                    contentType = response.ContentType;
+                    memoryStream = new MemoryStream();
+                    response.GetResponseStream().CopyTo(memoryStream);
+                }
+            }
+
+            // Ico file
+            if (_IsContentTypeIco(contentType))
+            {
                 try
                 {
-                    images.Add(Image.FromStream(memoryStream));
+                    foreach (var size in _ExtractIcoSizes(memoryStream))
+                    {
+                        memoryStream.Position = 0;
+                        images.Add(IconImage.FromIco(memoryStream, size));
+                    }
+                    return images;
                 }
-                catch (ArgumentException) {}
+
+                // Sometimes a website lies about "ico".
+                catch (EndOfStreamException) { }
+                catch (ArgumentException) { }
+                // We'll let this fall through to try another image type.
+                memoryStream.Position = 0;
             }
+
+            // Other image type
+            try
+            {
+                images.Add(IconImage.FromStream(memoryStream));
+            }
+            catch (ArgumentException) {}
             return images;
         }
 
 
         // Extract image sizes from ICO file
-        private IEnumerable<Size> _ExtractIcoSizes(Stream stream)
+        private IEnumerable<IconSize> _ExtractIcoSizes(Stream stream)
         {
             var reader = new BinaryReader(stream, Encoding.UTF8, true);
 
@@ -123,7 +148,7 @@ namespace FaviconFetcher
             stream.Seek(4000, SeekOrigin.Begin);
             var count = reader.ReadInt16();
 
-            var sizes = new List<Size>();
+            var sizes = new List<IconSize>();
             for (var i = 0; i != count; ++i)
             {
                 var offset = 6 + i * 16;
@@ -132,7 +157,7 @@ namespace FaviconFetcher
                 if (width == 0) width = 256;
                 int height = reader.ReadByte();
                 if (height == 0) height = 256;
-                sizes.Add(new Size(width, height));
+                sizes.Add(new IconSize(width, height));
             }
 
             return sizes;

--- a/FaviconFetcher/ISource.cs
+++ b/FaviconFetcher/ISource.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -28,6 +27,6 @@ namespace FaviconFetcher
         /// </remarks>
         /// <param name="uri">The URI of the image file to download.</param>
         /// <returns>All of the images found within the file, or an empty list.</returns>
-        IEnumerable<Image> DownloadImages(Uri uri);
+        IEnumerable<IconImage> DownloadImages(Uri uri);
     }
 }

--- a/FaviconFetcher/ScanResult.cs
+++ b/FaviconFetcher/ScanResult.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -20,6 +19,6 @@ namespace FaviconFetcher
         /// <summary>
         /// Expected size of the favicon.
         /// </summary>
-        public Size ExpectedSize { get; set; }
+        public IconSize ExpectedSize { get; set; }
     }
 }

--- a/FaviconFetcher/SubScanners/BrowserconfigXmlScanner.cs
+++ b/FaviconFetcher/SubScanners/BrowserconfigXmlScanner.cs
@@ -1,7 +1,6 @@
 ﻿using FaviconFetcher.Utility;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -71,16 +70,16 @@ namespace FaviconFetcher.SubScanners
                 switch (found)
                 {
                     case "<square70x70logo":
-                        _AddResult(attributes["src"], new Size(70, 70));
+                        _AddResult(attributes["src"], new IconSize(70, 70));
                         break;
                     case "<square150x150logo":
-                        _AddResult(attributes["src"], new Size(150, 150));
+                        _AddResult(attributes["src"], new IconSize(150, 150));
                         break;
                     case "<wide310x150logo":
-                        _AddResult(attributes["src"], new Size(310, 150));
+                        _AddResult(attributes["src"], new IconSize(310, 150));
                         break;
                     case "<square310x310logo":
-                        _AddResult(attributes["src"], new Size(310, 310));
+                        _AddResult(attributes["src"], new IconSize(310, 310));
                         break;
                 }
             }
@@ -156,7 +155,7 @@ namespace FaviconFetcher.SubScanners
             return builder.ToString();
         }
 
-        private void _AddResult(string uri, Size size)
+        private void _AddResult(string uri, IconSize size)
         {
             try {
                 Results.Add(new ScanResult

--- a/FaviconFetcher/SubScanners/DefaultScanner.cs
+++ b/FaviconFetcher/SubScanners/DefaultScanner.cs
@@ -1,7 +1,6 @@
 ﻿using FaviconFetcher.Utility;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -31,7 +30,7 @@ namespace FaviconFetcher.SubScanners
         }
 
 
-        private void _AddResult(Size expectedSize, string href)
+        private void _AddResult(IconSize expectedSize, string href)
         {
             try
             {
@@ -119,7 +118,7 @@ namespace FaviconFetcher.SubScanners
                 return;
 
             // Get the sizes specified
-            var sizes = new List<Size>();
+            var sizes = new List<IconSize>();
             if (attributes.ContainsKey("sizes"))
             {
                 foreach (var size in attributes["sizes"].Split(' '))
@@ -133,14 +132,14 @@ namespace FaviconFetcher.SubScanners
                     if (!int.TryParse(parts[1], out int height))
                         continue;
 
-                    sizes.Add(new Size(width, height));
+                    sizes.Add(new IconSize(width, height));
                 }
             }
 
             // If no valid sizes, try some deduction...
             if (sizes.Count == 0) {
                 if (rel.Contains("apple"))
-                    sizes.Add(new Size(57, 57));
+                    sizes.Add(new IconSize(57, 57));
                 else
                 {
                     int finalSize = 0, currentSize = 0;
@@ -154,13 +153,13 @@ namespace FaviconFetcher.SubScanners
                             finalSize = currentSize;
                     }
                     if (finalSize > 0)
-                        sizes.Add(new Size(finalSize, finalSize));
+                        sizes.Add(new IconSize(finalSize, finalSize));
                 }
             }
 
             // If still no valid size, just use a default 16x16.
             if (sizes.Count == 0)
-                sizes.Add(new Size(16, 16));
+                sizes.Add(new IconSize(16, 16));
 
             // Now we can finally add the favicons, one instance for each size
             foreach (var size in sizes)

--- a/FaviconFetcher/SubScanners/FaviconIcoScanner.cs
+++ b/FaviconFetcher/SubScanners/FaviconIcoScanner.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -25,7 +24,7 @@ namespace FaviconFetcher.SubScanners
             Results.Add(new ScanResult
             {
                 Location = new Uri(TargetUri, "/favicon.ico"),
-                ExpectedSize = new Size(16, 16)
+                ExpectedSize = new IconSize(16, 16)
             });
         }
 

--- a/FaviconFetcher/SubScanners/ManifestJsonScanner.cs
+++ b/FaviconFetcher/SubScanners/ManifestJsonScanner.cs
@@ -1,7 +1,6 @@
 ﻿using FaviconFetcher.Utility;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -76,7 +75,7 @@ namespace FaviconFetcher.SubScanners
                 {
                     Results.Add(new ScanResult
                     {
-                        ExpectedSize = new Size(width, height),
+                        ExpectedSize = new IconSize(width, height),
                         Location = new Uri(TargetUri, icon.src)
                     });
                 }

--- a/FaviconFetcher/Utility/FetchJob.cs
+++ b/FaviconFetcher/Utility/FetchJob.cs
@@ -1,7 +1,6 @@
 ﻿using ConcurrentPriorityQueue;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -21,7 +20,7 @@ namespace FaviconFetcher.Utility
         // Options for the fetch
         FetchOptions Options;
 
-        ConcurrentPriorityQueue<Image, double> downloadedImages = new ConcurrentPriorityQueue<Image, double>();
+        ConcurrentPriorityQueue<IconImage, double> downloadedImages = new ConcurrentPriorityQueue<IconImage, double>();
         ConcurrentPriorityQueue<ScanResult, double> notVerified = new ConcurrentPriorityQueue<ScanResult, double>();
 
         public FetchJob(ISource source, Uri uri, FetchOptions options)
@@ -38,7 +37,7 @@ namespace FaviconFetcher.Utility
         }
 
         // Scan and fetches best icon per Options.
-        public Image ScanAndFetch()
+        public IconImage ScanAndFetch()
         {
             var parsedUris = new HashSet<Uri>();
             foreach (var possibleIcon in new Scanner(Source).Scan(TargetUri))
@@ -79,7 +78,7 @@ namespace FaviconFetcher.Utility
 
 
         // Downloads images. If perfect found, returns it.
-        private Image DownloadImages_ReturnPerfect(Uri uri)
+        private IconImage DownloadImages_ReturnPerfect(Uri uri)
         {
             foreach (var image in Source.DownloadImages(uri))
             {
@@ -96,7 +95,7 @@ namespace FaviconFetcher.Utility
         }
 
         // Gets the distance between a size and the perfect size
-        private double _GetDistance(Size size)
+        private double _GetDistance(IconSize size)
         {
             // Considering the sizes as points, we can find the distance 
             // between them by using the Pythagorean Theorem.
@@ -106,7 +105,7 @@ namespace FaviconFetcher.Utility
         }
 
         // Is a size within the min/max range?
-        private bool _IsInRange(Size size)
+        private bool _IsInRange(IconSize size)
         {
             if (Options.RequireSquare && size.Width != size.Height)
                 return false;
@@ -122,9 +121,9 @@ namespace FaviconFetcher.Utility
         }
 
         // Is a size a perfect match?
-        private bool _IsPerfect(Size size)
+        private bool _IsPerfect(IconSize size)
         {
-            if (Options.PerfectSize == Size.Empty)
+            if (Options.PerfectSize == IconSize.Empty)
                 return false;
             return size == Options.PerfectSize;
         }


### PR DESCRIPTION
For portability between desktop and mobile applications and use with Portable Class Libraries, these changes replace the System.Drawing dependency with SkiaSharp.