### PR TITLE
Fix Scanner cannot locate links not located outside HTML head element 

### DIFF
--- a/FaviconFetcher/SubScanners/DefaultScanner.cs
+++ b/FaviconFetcher/SubScanners/DefaultScanner.cs
@@ -62,7 +62,7 @@ namespace FaviconFetcher.SubScanners
 
             while (!parser.EndOfStream)
             {
-                switch (parser.CaseInsensitiveSkipUntil("</head", "<base", "<link", "<meta"))
+                switch (parser.CaseInsensitiveSkipUntil("<base", "<link", "<meta", "</body"))
                 {
                     case "<base": _ParseBase(parser); break;
                     case "<link": _ParseLink(parser); break;


### PR DESCRIPTION
Resolves Issue #18 and causes the HTML parser to read to the end of the body, locating icon link tags that are valid but improperly placed.